### PR TITLE
fix(test): support PHPStan 2.2 AnalysisResult 12-arg constructor

### DIFF
--- a/tests/FriendlyErrorFormatterTest.php
+++ b/tests/FriendlyErrorFormatterTest.php
@@ -290,7 +290,13 @@ final class FriendlyErrorFormatterTest extends ErrorFormatterTestCase
             return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), true, []);
         }
 
+        // compatibility to 2.2.0 or later (added $processedFiles)
+        if (12 === $numOfParams) {
+            // @phpstan-ignore-next-line
+            return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), true, [], []);
+        }
+
         // @phpstan-ignore-next-line
-        return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), false);
+        return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), true, [], []);
     }
 }


### PR DESCRIPTION
## Problem

All unit test jobs are failing (e.g. on #48) with:

```
ArgumentCountError: Too few arguments to function
PHPStan\Command\AnalysisResult::__construct(), 10 passed ... and at least 11 expected
```

This is unrelated to the dependency bumps in the Renovate PR — CI runs `composer update`, which now pulls **PHPStan 2.2.x**. PHPStan **2.2.0** added a 12th constructor argument (`$processedFiles`) to `PHPStan\Command\AnalysisResult`, so its reflected parameter count is now `12`.

The test helper `createAnalysisResult()` branches on the parameter count but only handled up to `11`, falling through to a stale fallback that passed just 10 args.

## Fix

- Add a branch for the 12-parameter signature (PHPStan 2.2.0+, with `$processedFiles`)
- Update the stale fallback to the latest 12-arg signature

## Verification

Ran the suite in Docker against both ends of the supported range:

| Resolution | PHPStan | Result |
|---|---|---|
| `--prefer-stable` | 2.2.1 (12 params) | 15/15 ✅ |
| `--prefer-lowest` | 2.1.32 (11 params) | 15/15 ✅ |

Once this lands on `main`, rebasing/re-running #48 will turn its CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)